### PR TITLE
feat: focus markers in country

### DIFF
--- a/src/pages/timeline.module.scss
+++ b/src/pages/timeline.module.scss
@@ -31,7 +31,12 @@
 
   .country {
     display: inline-block;
+    border: none;
+    background-color: transparent;
     cursor: pointer;
+    font-family: 'Josefin Sans', sans-serif;
+    font-size: 16px;
+    font-weight: 300;
 
     &:not(:last-child) {
       margin-right: 2rem;

--- a/src/pages/timeline.module.scss
+++ b/src/pages/timeline.module.scss
@@ -31,6 +31,7 @@
 
   .country {
     display: inline-block;
+    cursor: pointer;
 
     &:not(:last-child) {
       margin-right: 2rem;

--- a/src/pages/timeline.tsx
+++ b/src/pages/timeline.tsx
@@ -200,16 +200,14 @@ const Timeline: NextPage<TimelineProps> = ({ countries, ne, sw }) => {
 
       <div className={styles.list} ref={listContainer}>
         {countries.map(({ country, flag, name }) => (
-          <div
+          <button
             className={styles.country}
             key={country}
             onClick={() => focusMarkersInCountry(country)}
             onKeyDown={(e) => e.key === 'Enter' && focusMarkersInCountry(country)}
-            role="button"
-            tabIndex={0}
           >
             {flag} {name}
-          </div>
+          </button>
         ))}
       </div>
 

--- a/src/pages/timeline.tsx
+++ b/src/pages/timeline.tsx
@@ -184,7 +184,7 @@ const Timeline: NextPage<TimelineProps> = ({ countries, ne, sw }) => {
     };
   }, [placeMarkers]);
 
-  const flyToCountry = useCallback(
+  const focusMarkersInCountry = useCallback(
     (country: string) => {
       const countryMarkers = markers.filter((marker) => marker.country === country);
       const { sw: s, ne: n } = boundingCoordinates(countryMarkers);
@@ -203,8 +203,8 @@ const Timeline: NextPage<TimelineProps> = ({ countries, ne, sw }) => {
           <div
             className={styles.country}
             key={country}
-            onClick={() => flyToCountry(country)}
-            onKeyDown={(e) => e.key === 'Enter' && flyToCountry(country)}
+            onClick={() => focusMarkersInCountry(country)}
+            onKeyDown={(e) => e.key === 'Enter' && focusMarkersInCountry(country)}
             role="button"
             tabIndex={0}
           >

--- a/src/pages/timeline.tsx
+++ b/src/pages/timeline.tsx
@@ -184,13 +184,30 @@ const Timeline: NextPage<TimelineProps> = ({ countries, ne, sw }) => {
     };
   }, [placeMarkers]);
 
+  const flyToCountry = useCallback(
+    (country: string) => {
+      const countryMarkers = markers.filter((marker) => marker.country === country);
+      const { sw: s, ne: n } = boundingCoordinates(countryMarkers);
+
+      map.current.fitBounds([s, n]);
+    },
+    [markers]
+  );
+
   return (
     <>
       <div className={styles.map} id="map" ref={mapContainer} />
 
       <div className={styles.list} ref={listContainer}>
         {countries.map(({ country, flag, name }) => (
-          <div className={styles.country} key={country}>
+          <div
+            className={styles.country}
+            key={country}
+            onClick={() => flyToCountry(country)}
+            onKeyDown={(e) => e.key === 'Enter' && flyToCountry(country)}
+            role="button"
+            tabIndex={0}
+          >
             {flag} {name}
           </div>
         ))}

--- a/src/pages/timeline.tsx
+++ b/src/pages/timeline.tsx
@@ -187,9 +187,14 @@ const Timeline: NextPage<TimelineProps> = ({ countries, ne, sw }) => {
   const focusMarkersInCountry = useCallback(
     (country: string) => {
       const countryMarkers = markers.filter((marker) => marker.country === country);
-      const { sw: s, ne: n } = boundingCoordinates(countryMarkers);
 
-      map.current.fitBounds([s, n], { padding: 100 });
+      if (countryMarkers.length === 1) {
+        const [{ lat, lng }] = countryMarkers;
+        map.current.flyTo({ center: [lng, lat], zoom: 9 });
+      } else {
+        const { sw: s, ne: n } = boundingCoordinates(countryMarkers);
+        map.current.fitBounds([s, n], { padding: 100 });
+      }
     },
     [markers]
   );

--- a/src/pages/timeline.tsx
+++ b/src/pages/timeline.tsx
@@ -189,7 +189,7 @@ const Timeline: NextPage<TimelineProps> = ({ countries, ne, sw }) => {
       const countryMarkers = markers.filter((marker) => marker.country === country);
       const { sw: s, ne: n } = boundingCoordinates(countryMarkers);
 
-      map.current.fitBounds([s, n]);
+      map.current.fitBounds([s, n], { padding: 100 });
     },
     [markers]
   );

--- a/src/pages/timeline.tsx
+++ b/src/pages/timeline.tsx
@@ -11,6 +11,7 @@ import { AuthorizationScopes } from '@entities/Jwt';
 import { Marker as MarkerEntity } from '@entities/Marker';
 import { Country } from '@lib/countryCodes';
 import { countryFlags } from '@lib/countryFlags';
+import { boundingCoordinates } from '@utils/boundingCoordinates';
 import { splitCase } from '@utils/casing';
 import { Config } from '@utils/config';
 import {
@@ -30,27 +31,7 @@ export interface TimelineProps {
 export const getStaticProps: GetStaticProps<DefaultState & TimelineProps> = async ({ locale }) => {
   const markers = await MarkerEntity.getAll();
 
-  const ne: LngLatLike = markers.length
-    ? { lat: markers[0].lat, lng: markers[0].lng }
-    : { lat: 42.35, lng: -70.9 };
-  const sw = { ...ne };
-  [...markers].slice(-10).forEach((lngLat) => {
-    if (ne.lng < lngLat.lng) {
-      ne.lng = lngLat.lng;
-    }
-
-    if (ne.lat < lngLat.lat) {
-      ne.lat = lngLat.lat;
-    }
-
-    if (sw.lng > lngLat.lng) {
-      sw.lng = lngLat.lng;
-    }
-
-    if (sw.lat > lngLat.lat) {
-      sw.lat = lngLat.lat;
-    }
-  });
+  const { sw, ne } = boundingCoordinates(markers);
 
   // filter country flags to avoid sending massive payload to client
   const countryMappings = Object.fromEntries(Object.entries(Country).map((a) => a.reverse()));

--- a/src/utils/boundingCoordinates.ts
+++ b/src/utils/boundingCoordinates.ts
@@ -1,0 +1,31 @@
+import { LngLatLike } from 'mapbox-gl';
+import { Marker } from '@entities/Marker';
+
+export const boundingCoordinates = (markers: Marker[]): { ne: LngLatLike; sw: LngLatLike } => {
+  const ne: LngLatLike = markers.length
+    ? { lat: markers[0].lat, lng: markers[0].lng }
+    : { lat: 42.35, lng: -70.9 };
+  const sw = { ...ne };
+  [...markers].slice(-10).forEach((lngLat) => {
+    if (ne.lng < lngLat.lng) {
+      ne.lng = lngLat.lng;
+    }
+
+    if (ne.lat < lngLat.lat) {
+      ne.lat = lngLat.lat;
+    }
+
+    if (sw.lng > lngLat.lng) {
+      sw.lng = lngLat.lng;
+    }
+
+    if (sw.lat > lngLat.lat) {
+      sw.lat = lngLat.lat;
+    }
+  });
+
+  return {
+    ne,
+    sw,
+  };
+};


### PR DESCRIPTION
Purpose:
- focus markers in a given country when clicking the country from the list

Issues:
1. Should this feature focus the markers within the country clicked or focus the entire country? These changes focus the markers themselves and aren't aware of the country bounds.

2. What should the desired zoom level be? Currently, the map repositions to use the outermost markers as the "edge" but IMO this should be decreased (see below)
<img width="839" alt="Screen Shot 2022-10-20 at 5 36 43 PM" src="https://user-images.githubusercontent.com/35714338/197085621-e07859db-e726-468c-a7eb-d1b1eb1b36d4.png">

furthermore, the map zooms in all the way if there is only a single marker in that country, which looks weird.

3. I believe we should add hover styles to the countries to further signify clicking them does something. How would you like this to look?

